### PR TITLE
Necessary breaking changes in core lib to use with Secret Network V1.7 after the mainnet upgrade

### DIFF
--- a/src/SecretNET.NFT.csproj
+++ b/src/SecretNET.NFT.csproj
@@ -20,7 +20,7 @@
 		<Title>SecretNET.NFT is a layer on top of the SecretNET client (for the Secret Network Blockchain) which supports all methods of the reference implementation of the SNIP721 contract. </Title>
 		<Description>SecretNET.NFT is a layer on top of Secret.NET which supports all methods of the reference implementation of the SNIP721 contract. The Secret Network blockchain (L1 / Cosmos), is the first privacy smart contract blockchain that processes and stores data on-chain in encrypted form (SGX). </Description>
 		<Authors>Codemonkey</Authors>
-		<Version>0.3.11-beta</Version>
+		<Version>0.3.11</Version>
 		<PackageProjectUrl>https://github.com/0xxCodemonkey/SecretNET.NFT</PackageProjectUrl>
 		<PackageIcon>SecretNetwork_Logo.png</PackageIcon>
 		<PackageReadmeFile>NuGet_README.md</PackageReadmeFile>
@@ -42,7 +42,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SecretNET" Version="0.3.11-beta" />
+	  <PackageReference Include="SecretNET" Version="0.3.11" />
 	</ItemGroup>
 
 </Project>

--- a/src/SecretNET.NFT.csproj
+++ b/src/SecretNET.NFT.csproj
@@ -20,13 +20,13 @@
 		<Title>SecretNET.NFT is a layer on top of the SecretNET client (for the Secret Network Blockchain) which supports all methods of the reference implementation of the SNIP721 contract. </Title>
 		<Description>SecretNET.NFT is a layer on top of Secret.NET which supports all methods of the reference implementation of the SNIP721 contract. The Secret Network blockchain (L1 / Cosmos), is the first privacy smart contract blockchain that processes and stores data on-chain in encrypted form (SGX). </Description>
 		<Authors>Codemonkey</Authors>
-		<Version>0.3.10</Version>
+		<Version>0.3.11-beta</Version>
 		<PackageProjectUrl>https://github.com/0xxCodemonkey/SecretNET.NFT</PackageProjectUrl>
 		<PackageIcon>SecretNetwork_Logo.png</PackageIcon>
 		<PackageReadmeFile>NuGet_README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/0xxCodemonkey/SecretNET.NFT</RepositoryUrl>
 		<PackageTags>NFT;Secret Network;Blockchain;Privacy;Cosmos-SDK;IBC;MAUI;Crypto;Web3;</PackageTags>
-		<PackageReleaseNotes>Update SecretNET Core Client (0.3.10)</PackageReleaseNotes>
+		<PackageReleaseNotes>Update SecretNET Core Client (0.3.11-beta)</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -42,7 +42,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SecretNET" Version="0.3.10" />
+	  <PackageReference Include="SecretNET" Version="0.3.11-beta" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Older versions of Secret.NET will not work anymore!!

- Change key reading of the key used for transactions; update proto files
- Necessary for Secret Network V1.7